### PR TITLE
Relax requirement that argument is non-null

### DIFF
--- a/vtkLookingGlassInterface.cxx
+++ b/vtkLookingGlassInterface.cxx
@@ -451,21 +451,25 @@ void vtkLookingGlassInterface::DrawLightFieldInternal(
 
 void vtkLookingGlassInterface::ReleaseGraphicsResources(vtkWindow* w)
 {
-  assert("pre: w_exists" && w != nullptr);
-
-  if (this->QuiltTexture)
+  if (this->QuiltTexture && w)
   {
     this->QuiltTexture->ReleaseGraphicsResources(w);
   }
   if (this->RenderFramebuffer)
   {
-    this->RenderFramebuffer->ReleaseGraphicsResources(w);
+    if (w)
+    {
+      this->RenderFramebuffer->ReleaseGraphicsResources(w);
+    }
     this->RenderFramebuffer->UnRegister(this);
     this->RenderFramebuffer = nullptr;
   }
   if (this->QuiltFramebuffer)
   {
-    this->QuiltFramebuffer->ReleaseGraphicsResources(w);
+    if (w)
+    {
+      this->QuiltFramebuffer->ReleaseGraphicsResources(w);
+    }
     this->QuiltFramebuffer->UnRegister(this);
     this->QuiltFramebuffer = nullptr;
   }


### PR DESCRIPTION
Since ReleaseGraphicsResources is expected to delete some member
variables, it should be able to do so when the parameter is null.