### PR TITLE
macos: Explicitly look for connected Looking Glass display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 vtk_module_find_package(PACKAGE HoloPlayCore)
 vtk_module_link(VTK::RenderingLookingGlass
     PRIVATE HoloPlayCore::HoloPlayCore)
+if (APPLE)
+  vtk_module_link(VTK::RenderingLookingGlass
+    PRIVATE "-framework IOKit")
+endif ()
 
 # Copy the FindHoloPlayCore.cmake file to the build directory
 if (DEFINED vtk_cmake_build_dir)

--- a/vtkLookingGlassInterface.cxx
+++ b/vtkLookingGlassInterface.cxx
@@ -80,6 +80,8 @@ vtkOpenGLRenderWindow* vtkLookingGlassInterface::CreateLookingGlassRenderWindow(
 #ifdef VTK_USE_COCOA
   return vtkCocoaLookingGlassRenderWindow::New();
 #endif
+
+  return nullptr;
 }
 
 vtkStandardNewMacro(vtkLookingGlassInterface);
@@ -147,10 +149,6 @@ vtkOpenGLRenderWindow* vtkLookingGlassInterface::CreateSharedLookingGlassRenderW
   renWin->SetSize(this->DisplaySize[0], this->DisplaySize[1]);
   renWin->SetPosition(this->DisplayPosition[0], this->DisplayPosition[1]);
   renWin->BordersOff();
-
-  // #ifdef VTK_USE_COCOA
-  //   renWin->FullScreenOn();
-  // #endif
 
   return renWin;
 }


### PR DESCRIPTION
Look through the list of connected displays and if a Looking Glass
display is found, create the window on it.