### PR TITLE
Mac display by device index

### DIFF
--- a/Testing/Cxx/TestDragon.cxx
+++ b/Testing/Cxx/TestDragon.cxx
@@ -28,7 +28,7 @@
 int TestDragon(int argc, char* argv[])
 {
   vtkOpenGLRenderWindow *renderWindow =
-    vtkLookingGlassInterface::CreateLookingGlassRenderWindow();
+    vtkLookingGlassInterface::CreateLookingGlassRenderWindow(0);
   vtkNew<vtkRenderer> renderer;
   vtkNew<vtkRenderWindowInteractor> iren;
 

--- a/vtkCocoaLookingGlassRenderWindow.h
+++ b/vtkCocoaLookingGlassRenderWindow.h
@@ -48,6 +48,11 @@ public:
    */
   void ReleaseGraphicsResources(vtkWindow*) override;
 
+  /**
+   * Give the window a chance to be created on the Looking Glass display.
+   */
+  void Initialize() override;
+
 protected:
   vtkCocoaLookingGlassRenderWindow();
   ~vtkCocoaLookingGlassRenderWindow() override;

--- a/vtkCocoaLookingGlassRenderWindow.h
+++ b/vtkCocoaLookingGlassRenderWindow.h
@@ -53,6 +53,11 @@ public:
    */
   void Initialize() override;
 
+  /**
+   * Set index of the Looking Glass device on which this window should appear.
+   */
+  void SetLGDeviceIndex(int index);
+
 protected:
   vtkCocoaLookingGlassRenderWindow();
   ~vtkCocoaLookingGlassRenderWindow() override;

--- a/vtkCocoaLookingGlassRenderWindow.mm
+++ b/vtkCocoaLookingGlassRenderWindow.mm
@@ -13,3 +13,48 @@
 
 #define className vtkCocoaLookingGlassRenderWindow
 #include "vtkLookingGlassRenderWindowImpl.h"
+
+#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
+#import <IOKit/graphics/IOGraphicsLib.h>
+#include "HoloPlayCore.h"
+
+//------------------------------------------------------------------------------
+void vtkCocoaLookingGlassRenderWindow::Initialize()
+{
+  // Limited to device 0 fow now
+  char buf[1000];
+  int deviceIndex = this->Interface->GetDeviceIndex();
+  hpc_GetDeviceHDMIName(deviceIndex, buf, 1000);
+  std::string deviceName(buf);
+
+  // Default to display 1, assuming the LG display is the only auxilliary display
+  int displayId = 1;
+
+  // Explicitly look for the LG display
+  int screenIndex = 0;
+  NSArray *screens = [NSScreen screens];
+  for (NSScreen *screen in screens)
+  {
+    int currentDisplayID = [[[screen deviceDescription] valueForKey:@"NSScreenNumber"] intValue];
+    NSDictionary *deviceInfo =
+      (NSDictionary *)CFBridgingRelease(IODisplayCreateInfoDictionary(CGDisplayIOServicePort(currentDisplayID),
+                                                                      kIODisplayOnlyPreferredName));
+    NSDictionary *localizedNames = [deviceInfo objectForKey:[NSString stringWithUTF8String:kDisplayProductName]];
+
+    NSString *screenName = nil;
+    if ([localizedNames count] > 0) {
+      screenName = [localizedNames objectForKey:[[localizedNames allKeys] objectAtIndex:0]];
+      std::string screenNameString = std::string([screenName UTF8String]);
+      if (screenNameString == deviceName)
+      {
+        displayId = screenIndex;
+        break;
+      }
+    }
+    ++screenIndex;
+  }
+  this->SetDisplayId(&displayId);
+
+  this->Superclass::Initialize();
+}

--- a/vtkLookingGlassInterface.cxx
+++ b/vtkLookingGlassInterface.cxx
@@ -69,19 +69,21 @@ IN THE SOFTWARE.
 #endif
 
 //------------------------------------------------------------------------------
-vtkOpenGLRenderWindow* vtkLookingGlassInterface::CreateLookingGlassRenderWindow()
+vtkOpenGLRenderWindow* vtkLookingGlassInterface::CreateLookingGlassRenderWindow(int deviceIndex)
 {
 #ifdef WIN32
-  return vtkWin32LookingGlassRenderWindow::New();
+  auto renWin = vtkWin32LookingGlassRenderWindow::New();
 #endif
 #ifdef VTK_USE_X
-  return vtkXLookingGlassRenderWindow::New();
+  auto renWin = vtkXLookingGlassRenderWindow::New();
 #endif
 #ifdef VTK_USE_COCOA
-  return vtkCocoaLookingGlassRenderWindow::New();
+  auto renWin = vtkCocoaLookingGlassRenderWindow::New();
 #endif
 
-  return nullptr;
+  renWin->SetLGDeviceIndex(deviceIndex);
+
+  return renWin;
 }
 
 vtkStandardNewMacro(vtkLookingGlassInterface);

--- a/vtkLookingGlassInterface.h
+++ b/vtkLookingGlassInterface.h
@@ -38,8 +38,10 @@ public:
 
   // create an OpenGLRenderWindow suitable for looking glass
   // just a convenience method to handle the OS specific subclasses
-  // in a generic manner.
-  static vtkOpenGLRenderWindow* CreateLookingGlassRenderWindow();
+  // in a generic manner. The deviceIndex argument specifies the
+  // index of the LookingGlass device on which the window should be placed
+  // (presently supported only on macOS).
+  static vtkOpenGLRenderWindow* CreateLookingGlassRenderWindow(int deviceIndex = 0);
 
   // Get the display posiiton for the looking glass device
   vtkGetVector2Macro(DisplayPosition, int);

--- a/vtkLookingGlassRenderWindowImpl.h
+++ b/vtkLookingGlassRenderWindowImpl.h
@@ -209,3 +209,9 @@ int* className::GetSize(void)
 
   return this->Superclass::GetSize();
 }
+
+//------------------------------------------------------------------------------
+void className::SetLGDeviceIndex(int index)
+{
+  this->Interface->SetDeviceIndex(index);
+}

--- a/vtkLookingGlassRenderWindowImpl.h
+++ b/vtkLookingGlassRenderWindowImpl.h
@@ -25,12 +25,6 @@
 
 #include "vtk_glew.h"
 
-#ifdef VTK_USE_COCOA
-#import <Cocoa/Cocoa.h>
-#import <Foundation/Foundation.h>
-#import <IOKit/graphics/IOGraphicsLib.h>
-#endif
-
 vtkStandardNewMacro(className);
 
 //------------------------------------------------------------------------------
@@ -43,34 +37,6 @@ className::className()
   this->BordersOff();
 #ifdef VTK_USE_COCOA
   this->FullScreenOn();
-  NSArray *screens = [NSScreen screens];
-
-  // Default to display 1, assuming the LG display is the only auxilliary display
-  int displayId = 1;
-
-  // Explicitly look for the LG display
-  int screenIndex = 0;
-  for (NSScreen *screen in screens)
-  {
-    int currentDisplayID = [[[screen deviceDescription] valueForKey:@"NSScreenNumber"] intValue];
-    NSDictionary *deviceInfo =
-      (NSDictionary *)CFBridgingRelease(IODisplayCreateInfoDictionary(CGDisplayIOServicePort(currentDisplayID),
-                                                                      kIODisplayOnlyPreferredName));
-    NSDictionary *localizedNames = [deviceInfo objectForKey:[NSString stringWithUTF8String:kDisplayProductName]];
-
-    NSString *screenName = nil;
-    if ([localizedNames count] > 0) {
-      screenName = [localizedNames objectForKey:[[localizedNames allKeys] objectAtIndex:0]];
-      std::string screenNameString = std::string([screenName UTF8String]);
-      if (screenNameString.substr(0, 4) == "LKGL")
-      {
-        displayId = screenIndex;
-        break;
-      }
-    }
-    ++screenIndex;
-  }
-  this->SetDisplayId(&displayId);
 #endif
 }
 

--- a/vtkWin32LookingGlassRenderWindow.h
+++ b/vtkWin32LookingGlassRenderWindow.h
@@ -48,6 +48,11 @@ public:
    */
   void ReleaseGraphicsResources(vtkWindow*) override;
 
+  /**
+   * Set index of the Looking Glass device on which this window should appear.
+   */
+  void SetLGDeviceIndex(int index);
+
 protected:
   vtkWin32LookingGlassRenderWindow();
   ~vtkWin32LookingGlassRenderWindow() override;

--- a/vtkXLookingGlassRenderWindow.h
+++ b/vtkXLookingGlassRenderWindow.h
@@ -48,6 +48,11 @@ public:
    */
   void ReleaseGraphicsResources(vtkWindow*) override;
 
+  /**
+   * Set index of the Looking Glass device on which this window should appear.
+   */
+  void SetLGDeviceIndex(int index);
+
 protected:
   vtkXLookingGlassRenderWindow();
   ~vtkXLookingGlassRenderWindow() override;


### PR DESCRIPTION
Refactors the code to take a LG device device index. On macos, use that device index to find the display on which the render window should be created. 