### PR TITLE
BUG: Copy FindHoloPlayCore into VTK build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,13 @@ if (DEFINED vtk_cmake_build_dir)
     COPYONLY)
 endif ()
 
+if (DEFINED vtk_cmake_destination AND VTK_BINARY_DIR)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/FindHoloPlayCore.cmake"
+    "${VTK_BINARY_DIR}/${vtk_cmake_destination}/FindHoloPlayCore.cmake"
+    COPYONLY)
+endif ()
+
 if (DEFINED vtk_cmake_destination)
   install(
     FILES "${CMAKE_CURRENT_SOURCE_DIR}/FindHoloPlayCore.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ if (DEFINED vtk_cmake_build_dir)
     COPYONLY)
 endif ()
 
+# Workaround limitation of VTK build-system preventing export module specific CMake variables
+# in module config files.
 if (DEFINED vtk_cmake_destination AND VTK_BINARY_DIR)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/FindHoloPlayCore.cmake"


### PR DESCRIPTION
Problem: FindHoloPlayCore.cmake is not exposed in the VTK build tree, so any application built against a VTK build tree that is build with LookingGlass Rendering enabled will have to have its own copy of FindHoloPlayCore.cmake

Solution: Place FindHoloPlayCore in the VTK_BINARY_DIR/vtk_cmake_destination directory during configuration so that applications that build against the VTK build tree can automatically discover it.