### PR TITLE
Change ogg extension to ogv

### DIFF
--- a/vtkLookingGlassInterface.cxx
+++ b/vtkLookingGlassInterface.cxx
@@ -86,7 +86,7 @@ static const char* MovieExtension = "avi";
 // Otherwise, use Ogg Theora.
 #include "vtkOggTheoraWriter.h"
 using MovieWriterClass = vtkOggTheoraWriter;
-static const char* MovieExtension = "ogg";
+static const char* MovieExtension = "ogv";
 #endif
 #endif
 


### PR DESCRIPTION
"ogv" is the preferred extension for ogg video files.

This won't affect functionality too much, however, since the ParaView
nightlies and releases will not be using ogv.