### PR TITLE
Add support for portrait devices

### DIFF
--- a/vtkLookingGlassInterface.cxx
+++ b/vtkLookingGlassInterface.cxx
@@ -294,10 +294,10 @@ void vtkLookingGlassInterface::SetupQuiltSettings(int preset)
   switch (preset)
   {
     case 0: // standard
-      this->QuiltSize[0] = 2048;
-      this->QuiltSize[1] = 2048;
-      this->QuiltTiles[0] = 4;
-      this->QuiltTiles[1] = 8;
+      this->QuiltSize[0] = 3360;
+      this->QuiltSize[1] = 3360;
+      this->QuiltTiles[0] = 8;
+      this->QuiltTiles[1] = 6;
       break;
     default:
     case 1: // hires

--- a/vtkLookingGlassRenderWindowImpl.h
+++ b/vtkLookingGlassRenderWindowImpl.h
@@ -124,6 +124,13 @@ void className::DoStereoRender()
         cam->DeepCopy(Cameras[count]);
         this->Interface->AdjustCamera(cam, tile);
 
+        // Lock aspect ratio to the size of the device. Otherwise it would be
+        // computed from this class GetSize() method and could be inverted
+        // depending on the quilt size.
+        double aspect = static_cast<double>(origSize[0]) / origSize[1];
+        cam->SetExplicitAspectRatio(aspect);
+        cam->UseExplicitAspectRatioOn();
+
         // limit the clipping range to limit parallax
         if (this->Interface->GetUseClippingLimits())
         {


### PR DESCRIPTION
@cquammen @aylward

I tried using the LookingGlassSDK v0.2.0 to support their Portrait device.

- No API changes nor CMake changes are expected for this new version. Everything builds fine.

- The only required change is to swap the QuiltTiles values to have a portrait oriented aspect ratio:
I could not find a way to get the device orientation using the SDK, so I used the DisplaySize.
Can you confirm that you get DisplaySize[0] > DisplaySize[1] with your landscape device (we only have portrait at KEU)?
I am not sure Initialize is the right place to do so, so don't hesitate if you want me to change something.

- UseHorizontalViewAngleOn() should be set on the camera for portrait mode. I left this to be handled by users in their code, but it should be documented somewhere, or done automatically in [vtkLookingGlassInterface::AdjustCamera](https://github.com/Kitware/LookingGlassVTKModule/blob/master/vtkLookingGlassInterface.cxx#L360). Let me know what you think.

