### PR TITLE
DOC: Provide instructions for obtaining and using HoloPlayCoreSDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,55 @@ The other approach is to use the vtkLookingGlassPass as you would normally
 use a render pass in a renderer. For an example of that approach please see
 Testing\Cxx\TestLookingGlassPass.cxx
 
-## Building
+## Build Requirements
 
-When building VTK turn on the remote module by setting
-VTK_MODULE_ENABLE_VTK_RenderingLookingGlass to YES and specifying the
+Building this modules requires the Looking Glass Factory's
+`HoloPlayCoreSDK`. You must request a copy of the HoloPlayCoreSDK
+directly from Looking Glass Factory.
+
+The SDK is described 
+[here](https://docs.lookingglassfactory.com/holoplay-core/holoplay-core-sdk).
+
+You can request access to their SDK
+[here](https://lookingglassfactory.com/software#holoplay-core).
+
+Access is granted nearly instantaneously.  Their SDK includes dylibs
+(shared libraries) for MacOS, Linux, and Windows (32 and 64bit).
+
+We recommend installing their SDK at the same level as the
+VTK source directory, so that it can be automatically found by VTK during
+compilation.  For example, if VTK souce is in `/src/VTK` on your system,
+then uncompress the HoloPlaceCoreSDK which is current in version 0.2.0 into
+the `/src` directory.   The path to the HoloPlayCoreSDK include directory
+would then be `/src/HoloPlayCore-0.2.0/HoloPlayCore/include`.  VTK can then
+automatically find the include and appropriate dylib files during CMake
+configuration of VTK,  otherwise you will have to specify the paths to
+those files manually during CMake configuration.
+
+## CMake Configuration of VTK
+
+When configuring VTK using CMake, enable this module by setting
+`VTK_MODULE_ENABLE_VTK_RenderingLookingGlass` to `YES` and specifying the
 HoloPlayCore include dir and library to where you have installed the
-HoloPlayCore SDK.
+HoloPlayCore SDK, if they are not automatically found.
 
-At this point build VTK as usual for your platform. We currently support
-Windows, OSX, and Linux platforms.
+## Compilation
+
+With this module enabled in CMake, build VTK as usual for your platform. We
+currently support Windows, OSX, and Linux platforms.
+
+## Running VTK applications
+
+Since the HoloPlayCoreSDK is distribued as shared libraries, their location
+must be known when executing a VTK-based application if that version of
+VTK was compiled with this module enabled.
+
+We recommend adding the path to the appropriate shared lib to your system's
+PATH/LD_LIBRARY_PATH variables.  They will then be automatically found
+when running VTK applications that were compiled with this module enabled.
+
+System-level access to the shared libs is also required when running the
+Python wrapped VTK if this module was enabled when it was compiled.
 
 ## Developement/Bug Reports
 
@@ -27,8 +67,8 @@ vtkLookingGlassInterface which is used by both the render window classes and
 the render pass implementations. This module should work, showing the quilt
 image even if no hardware is present.
 
-If you run into issues with this module please contact
-ken.martin@kitware.com
+If you run into issues with this module please submit a bug report at
+https://github.com/Kitware/LookingGlassVTKModule/issues
 
 ## License
 


### PR DESCRIPTION
Included links to LookingGlassFactory's description and application
for their HoloPlayCoreSDK.  Also specifically mentioned that the
SDK is required.