### PR TITLE
ENH: RenderingLookingGlass requires vtkMP4Writer - this makes that requirement explicit during configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,17 @@ if (VTK_USE_X)
   list(APPEND classes vtkXLookingGlassRenderWindow)
 elseif (WIN32)
   list(APPEND classes vtkWin32LookingGlassRenderWindow)
+  if (NOT VTK_USE_MICROSOFT_MEDIA_FOUNDATION OR NOT VTK_USE_VIDEO_FOR_WINDOWS)
+    message(FATAL_ERROR
+      "LookingGlass module requires"
+       " VTK_USE_MICROSOFT_MEDIA_FOUNDATION and"
+       " VTK_USE_VIDEO_FOR_WINODWS to be set to ON" )
+  endif()
 elseif (VTK_USE_COCOA)
   list(APPEND sources vtkCocoaLookingGlassRenderWindow.mm)
   list(APPEND headers vtkCocoaLookingGlassRenderWindow.h)
 endif()
+
 
 vtk_module_add_module(VTK::RenderingLookingGlass
   CLASSES ${classes}
@@ -25,7 +32,7 @@ list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
 vtk_module_find_package(PACKAGE HoloPlayCore)
 vtk_module_link(VTK::RenderingLookingGlass
-    PRIVATE HoloPlayCore::HoloPlayCore)
+    PUBLIC HoloPlayCore::HoloPlayCore)
 if (APPLE)
   vtk_module_link(VTK::RenderingLookingGlass
     PRIVATE "-framework IOKit")

--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ Testing\Cxx\TestLookingGlassPass.cxx
 
 ## Building
 
-When building VTK turn on the remote module by setting
-VTK_MODULE_ENABLE_VTK_RenderingLookingGlass to YES and specifying the
-HoloPlayCore include dir and library to where you have installed the
-HoloPlayCore SDK.
+When configuring VTK using CMake, turn on this remote module and its dependencies by setting
+
+1. VTK_MODULE_ENABLE_VTK_RenderingLookingGlass to YES
+2. VTK_USE_VIDEO_FOR_WINDOWS to ON
+3. VTK_USE_MICROSOFT_MEDIA_FOUNDATION to ON
+
+You must also specify 
+1. HoloPlayCore_INCLUDE_DIR
+2. HoloPlayCore_LIBRARY
+based on where you have installed the HoloPlayCore SDK.
 
 At this point build VTK as usual for your platform. We currently support
 Windows, OSX, and Linux platforms.


### PR DESCRIPTION
This requirement is now specified in the README and it is verified in the CMakeLists.txt file.

Requirements are that VTK_USE_MICROSOFT_MEDIA_FOUNDATION and VTK_USE_VIDEO_FOR_WINDOWS must be enabled.