### PR TITLE
Put common render code in a RenderQuilt() function

### DIFF
--- a/vtkLookingGlassInterface.cxx
+++ b/vtkLookingGlassInterface.cxx
@@ -676,10 +676,6 @@ void vtkLookingGlassInterface::RenderQuilt(vtkOpenGLRenderWindow* rw,
     aren->SetActiveCamera(newCam);
   }
 
-  // Make sure we can use offscreen buffers
-  auto prevUseOffScreenBuffers = rw->GetUseOffScreenBuffers();
-  rw->UseOffScreenBuffersOn();
-
   // loop over all the tiles and render then and blit them to the quilt
   for (int tile = 0; tile < tcount; ++tile)
   {
@@ -746,9 +742,6 @@ void vtkLookingGlassInterface::RenderQuilt(vtkOpenGLRenderWindow* rw,
     // Write out a movie frame if we are recording
     this->WriteQuiltMovieFrame();
   }
-
-  // Restore previous settings
-  rw->SetUseOffScreenBuffers(prevUseOffScreenBuffers);
 
   // restore the original camera settings
   int count = 0;

--- a/vtkLookingGlassInterface.cxx
+++ b/vtkLookingGlassInterface.cxx
@@ -52,6 +52,7 @@ IN THE SOFTWARE.
 #include "vtkOpenGLShaderCache.h"
 #include "vtkOpenGLState.h"
 #include "vtkPNGWriter.h"
+#include "vtkRendererCollection.h"
 #include "vtkShaderProgram.h"
 #include "vtkTextureObject.h"
 #include "vtkVectorOperators.h"
@@ -625,6 +626,132 @@ void vtkLookingGlassInterface::GetTilePosition(int tile, int pos[2])
 {
   pos[0] = (tile % this->QuiltTiles[0]) * this->RenderSize[0];
   pos[1] = (tile / this->QuiltTiles[0]) * this->RenderSize[1];
+}
+
+void vtkLookingGlassInterface::RenderQuilt(
+  vtkOpenGLRenderWindow* rw, std::function<void(void)>* renderFunc)
+{
+  vtkCollectionSimpleIterator rsit;
+
+  // loop over the tiles, render,and blit
+  vtkOpenGLFramebufferObject* renderFramebuffer;
+  vtkOpenGLFramebufferObject* quiltFramebuffer;
+  this->GetFramebuffers(rw, renderFramebuffer, quiltFramebuffer);
+
+  auto ostate = rw->GetState();
+
+  ostate->PushFramebufferBindings();
+  renderFramebuffer->Bind(GL_READ_FRAMEBUFFER);
+
+  int renderSize[2];
+  this->GetRenderSize(renderSize);
+
+  int tcount = this->GetNumberOfTiles();
+
+  // save the original camera settings
+  auto* renCol = rw->GetRenderers();
+  vtkRenderer* aren;
+  std::vector<vtkCamera*> Cameras;
+  for (renCol->InitTraversal(rsit); aren = renCol->GetNextRenderer(rsit);)
+  {
+    // Ugly piece of code - we need to know if the camera already
+    // exists or not. If it does not yet exist, we must reset the
+    // camera here - otherwise it will never be done (missing its
+    // oppportunity to be reset in the Render method of the
+    // vtkRenderer because it will already exist by that point...)
+    if (!aren->IsActiveCameraCreated())
+    {
+      aren->ResetCamera();
+    }
+    auto oldCam = aren->GetActiveCamera();
+    oldCam->SetLeftEye(1);
+    oldCam->Register(rw);
+    Cameras.push_back(oldCam);
+    vtkNew<vtkCamera> newCam;
+    aren->SetActiveCamera(newCam);
+  }
+
+  // Make sure we can use offscreen buffers
+  auto prevUseOffScreenBuffers = rw->GetUseOffScreenBuffers();
+  rw->UseOffScreenBuffersOn();
+
+  // loop over all the tiles and render then and blit them to the quilt
+  for (int tile = 0; tile < tcount; ++tile)
+  {
+    renderFramebuffer->Bind(GL_DRAW_FRAMEBUFFER);
+    ostate->vtkglViewport(0, 0, renderSize[0], renderSize[1]);
+    ostate->vtkglScissor(0, 0, renderSize[0], renderSize[1]);
+
+    int count = 0;
+    for (renCol->InitTraversal(rsit); aren = renCol->GetNextRenderer(rsit); ++count)
+    {
+      // adjust camera
+      vtkCamera* cam = aren->GetActiveCamera();
+      cam->DeepCopy(Cameras[count]);
+      this->AdjustCamera(cam, tile);
+
+      // limit the clipping range to limit parallax
+      if (this->GetUseClippingLimits())
+      {
+        double* cRange = cam->GetClippingRange();
+        double cameraDistance = cam->GetDistance();
+
+        double nearClippingLimit = this->GetNearClippingLimit();
+        double farClippingLimit = this->GetFarClippingLimit();
+
+        double newRange[2];
+        newRange[0] = cRange[0];
+        newRange[1] = cRange[1];
+        if (cRange[0] < cameraDistance * nearClippingLimit)
+        {
+          newRange[0] = cameraDistance * nearClippingLimit;
+        }
+        if (cRange[1] > cameraDistance * farClippingLimit)
+        {
+          newRange[1] = cameraDistance * farClippingLimit;
+        }
+        cam->SetClippingRange(newRange);
+      }
+    }
+
+    if (renderFunc)
+    {
+      (*renderFunc)();
+    }
+    else
+    {
+      renCol->Render();
+    }
+
+    quiltFramebuffer->Bind(GL_DRAW_FRAMEBUFFER);
+
+    int destPos[2];
+    this->GetTilePosition(tile, destPos);
+
+    // blit to quilt
+    ostate->vtkglViewport(destPos[0], destPos[1], renderSize[0], renderSize[1]);
+    ostate->vtkglScissor(destPos[0], destPos[1], renderSize[0], renderSize[1]);
+    glBlitFramebuffer(0, 0, renderSize[0], renderSize[1], destPos[0], destPos[1],
+      destPos[0] + renderSize[0], destPos[1] + renderSize[1], GL_COLOR_BUFFER_BIT, GL_LINEAR);
+  }
+  ostate->PopFramebufferBindings();
+
+  if (this->IsRecording)
+  {
+    // Write out a movie frame if we are recording
+    this->WriteQuiltMovieFrame();
+  }
+
+  // Restore previous settings
+  rw->SetUseOffScreenBuffers(prevUseOffScreenBuffers);
+
+  // restore the original camera settings
+  int count = 0;
+  for (renCol->InitTraversal(rsit); aren = renCol->GetNextRenderer(rsit); ++count)
+  {
+    aren->SetActiveCamera(Cameras[count]);
+    Cameras[count]->Delete();
+  }
 }
 
 void vtkLookingGlassInterface::SaveQuilt(vtkOpenGLRenderWindow* rw, const char* fileName)

--- a/vtkLookingGlassInterface.h
+++ b/vtkLookingGlassInterface.h
@@ -30,6 +30,7 @@ class vtkGenericMovieWriter;
 class vtkOpenGLFramebufferObject;
 class vtkOpenGLQuadHelper;
 class vtkOpenGLRenderWindow;
+class vtkRendererCollection;
 class vtkTextureObject;
 class vtkWindow;
 class vtkWindowToImageFilter;
@@ -165,13 +166,18 @@ public:
   // looking glass window to mirror it.
   vtkOpenGLRenderWindow* CreateSharedLookingGlassRenderWindow(vtkOpenGLRenderWindow* srcWin);
 
-  // Render the quilt using the provided render window. The `renderFunc` is an
-  // optional function to use for rendering instead of the `Render()` function
-  // on the renderers. This is important when custom rendering is required,
-  // such as in a vtkRenderPass, like the vtkLookingGlassPass. Note that you
-  // may need to modify the size of the render window to be that of the
-  // vtkLookingGlassInterface::GetRenderSize() before calling this function.
-  void RenderQuilt(vtkOpenGLRenderWindow* rw, std::function<void(void)>* renderFunc = nullptr);
+  // Render the quilt using the provided render window.
+  // The `renderers` argument defaults to all renderers on the render window,
+  // but can be provided to use only a subset of the renderers.
+  // The `renderFunc` is an optional function to use for rendering instead of
+  // the `Render()` function on the renderers. This is important when custom
+  // rendering is required, such as in a vtkRenderPass, like the
+  // vtkLookingGlassPass.
+  // Note that you may need to modify the size of the render window to be that
+  // of the vtkLookingGlassInterface::GetRenderSize() before calling this
+  // function.
+  void RenderQuilt(vtkOpenGLRenderWindow* rw, vtkRendererCollection* renderers = nullptr,
+    std::function<void(void)>* renderFunc = nullptr);
 
   /**
    * Save the quilt currently displayed in the render window as a PNG file.

--- a/vtkLookingGlassInterface.h
+++ b/vtkLookingGlassInterface.h
@@ -23,6 +23,8 @@
 #include "vtkRenderingLookingGlassModule.h" // For export macro
 #include "vtkObject.h"
 
+#include <functional>
+
 class vtkCamera;
 class vtkGenericMovieWriter;
 class vtkOpenGLFramebufferObject;
@@ -162,6 +164,14 @@ public:
   // the provided window. Such as when you want a desktop window and a
   // looking glass window to mirror it.
   vtkOpenGLRenderWindow* CreateSharedLookingGlassRenderWindow(vtkOpenGLRenderWindow* srcWin);
+
+  // Render the quilt using the provided render window. The `renderFunc` is an
+  // optional function to use for rendering instead of the `Render()` function
+  // on the renderers. This is important when custom rendering is required,
+  // such as in a vtkRenderPass, like the vtkLookingGlassPass. Note that you
+  // may need to modify the size of the render window to be that of the
+  // vtkLookingGlassInterface::GetRenderSize() before calling this function.
+  void RenderQuilt(vtkOpenGLRenderWindow* rw, std::function<void(void)>* renderFunc = nullptr);
 
   /**
    * Save the quilt currently displayed in the render window as a PNG file.

--- a/vtkLookingGlassPass.cxx
+++ b/vtkLookingGlassPass.cxx
@@ -20,6 +20,7 @@
 #include "vtkOpenGLRenderWindow.h"
 #include "vtkRenderState.h"
 #include "vtkRenderer.h"
+#include "vtkRendererCollection.h"
 
 vtkStandardNewMacro(vtkLookingGlassPass);
 
@@ -89,7 +90,11 @@ void vtkLookingGlassPass::Render(const vtkRenderState* s)
   s2.SetFrameBuffer(renderFramebuffer);
   std::function<void(void)> renderFunc = [this, &s2]() { this->DelegatePass->Render(&s2); };
 
-  this->Interface->RenderQuilt(renWin, &renderFunc);
+  // Only render with this single renderer
+  vtkNew<vtkRendererCollection> renderers;
+  renderers->AddItem(r);
+
+  this->Interface->RenderQuilt(renWin, renderers, &renderFunc);
   this->Interface->DrawLightField(renWin);
 
   vtkOpenGLCheckErrorMacro("failed after Render");

--- a/vtkLookingGlassRenderWindowImpl.h
+++ b/vtkLookingGlassRenderWindowImpl.h
@@ -13,17 +13,8 @@
  * This header includes code common to all OS specific RenderWindows
  */
 
-#include <vector>
-
-#include "vtkCamera.h"
 #include "vtkLookingGlassInterface.h"
 #include "vtkObjectFactory.h"
-#include "vtkOpenGLFramebufferObject.h"
-#include "vtkOpenGLState.h"
-#include "vtkRendererCollection.h"
-#include "vtkRenderingOpenGLConfigure.h"
-
-#include "vtk_glew.h"
 
 vtkStandardNewMacro(className);
 
@@ -59,129 +50,21 @@ void className::ReleaseGraphicsResources(vtkWindow* renWin)
 // display then render the resulting lightfield to the window
 void className::DoStereoRender()
 {
-  vtkCollectionSimpleIterator rsit;
-
   this->StereoUpdate();
-
-  // loop over the tiles, render,and blit
-  vtkOpenGLFramebufferObject* renderFramebuffer;
-  vtkOpenGLFramebufferObject* quiltFramebuffer;
-  this->Interface->GetFramebuffers(this, renderFramebuffer, quiltFramebuffer);
-
-  auto ostate = this->GetState();
-
-  ostate->PushFramebufferBindings();
-  renderFramebuffer->Bind(GL_READ_FRAMEBUFFER);
 
   int renderSize[2];
   this->Interface->GetRenderSize(renderSize);
 
-  int tcount = this->Interface->GetNumberOfTiles();
-
-  // save the original camera settings
-  vtkRenderer* aren;
-  std::vector<vtkCamera*> Cameras;
-  for (this->Renderers->InitTraversal(rsit); (aren = this->Renderers->GetNextRenderer(rsit));)
-  {
-    // Ugly piece of code - we need to know if the camera already
-    // exists or not. If it does not yet exist, we must reset the
-    // camera here - otherwise it will never be done (missing its
-    // oppportunity to be reset in the Render method of the
-    // vtkRenderer because it will already exist by that point...)
-    if (!aren->IsActiveCameraCreated())
-    {
-      aren->ResetCamera();
-    }
-    auto oldCam = aren->GetActiveCamera();
-    oldCam->SetLeftEye(1);
-    oldCam->Register(this);
-    Cameras.push_back(oldCam);
-    vtkNew<vtkCamera> newCam;
-    aren->SetActiveCamera(newCam);
-  }
-
-  // save the current size and temporarily set the new size to the render
-  // framebuffer size
   int origSize[2] = { this->Size[0], this->Size[1] };
   this->InStereoRender = true;
   this->Size[0] = renderSize[0];
   this->Size[1] = renderSize[1];
 
-  // loop over all the tiles and render then and blit them to the quilt
-  for (int tile = 0; tile < tcount; ++tile)
-  {
-    renderFramebuffer->Bind(GL_DRAW_FRAMEBUFFER);
-    ostate->vtkglViewport(0, 0, renderSize[0], renderSize[1]);
-    ostate->vtkglScissor(0, 0, renderSize[0], renderSize[1]);
+  this->Interface->RenderQuilt(this);
 
-    {
-      int count = 0;
-      for (this->Renderers->InitTraversal(rsit); (aren = this->Renderers->GetNextRenderer(rsit));
-           ++count)
-      {
-        // adjust camera
-        vtkCamera* cam = aren->GetActiveCamera();
-        cam->DeepCopy(Cameras[count]);
-        this->Interface->AdjustCamera(cam, tile);
-
-        // limit the clipping range to limit parallax
-        if (this->Interface->GetUseClippingLimits())
-        {
-          double* cRange = cam->GetClippingRange();
-          double cameraDistance = cam->GetDistance();
-
-          double nearClippingLimit = this->Interface->GetNearClippingLimit();
-          double farClippingLimit = this->Interface->GetFarClippingLimit();
-
-          double newRange[2];
-          newRange[0] = cRange[0];
-          newRange[1] = cRange[1];
-          if (cRange[0] < cameraDistance * nearClippingLimit)
-          {
-            newRange[0] = cameraDistance * nearClippingLimit;
-          }
-          if (cRange[1] > cameraDistance * farClippingLimit)
-          {
-            newRange[1] = cameraDistance * farClippingLimit;
-          }
-          cam->SetClippingRange(newRange);
-        }
-      }
-      this->Renderers->Render();
-    }
-
-    quiltFramebuffer->Bind(GL_DRAW_FRAMEBUFFER);
-
-    int destPos[2];
-    this->Interface->GetTilePosition(tile, destPos);
-
-    // blit to quilt
-    ostate->vtkglViewport(destPos[0], destPos[1], renderSize[0], renderSize[1]);
-    ostate->vtkglScissor(destPos[0], destPos[1], renderSize[0], renderSize[1]);
-    glBlitFramebuffer(0, 0, renderSize[0], renderSize[1], destPos[0], destPos[1],
-      destPos[0] + renderSize[0], destPos[1] + renderSize[1], GL_COLOR_BUFFER_BIT, GL_LINEAR);
-  }
-  ostate->PopFramebufferBindings();
-
-  // rertore the original size
   this->InStereoRender = false;
   this->Size[0] = origSize[0];
   this->Size[1] = origSize[1];
-
-  // restore the original camera settings
-  int count = 0;
-  for (this->Renderers->InitTraversal(rsit); (aren = this->Renderers->GetNextRenderer(rsit));
-       ++count)
-  {
-    aren->SetActiveCamera(Cameras[count]);
-    Cameras[count]->Delete();
-  }
-
-  // ostate->PushReadFramebufferBinding();
-  // quiltFramebuffer->Bind(GL_READ_FRAMEBUFFER);
-  // glBlitFramebuffer(
-  //   0, 0, 4096, 4096, 0, 0, this->Size[0], this->Size[1], GL_COLOR_BUFFER_BIT, GL_LINEAR);
-  // ostate->PopReadFramebufferBinding();
 
   this->Interface->DrawLightField(this);
 }


### PR DESCRIPTION
This moves common rendering code into a
`vtkLookingGlassInterface::RenderQuilt()` function. The common rendering
code is being moved from three places:

1. `vtkLookingGlassPass::Render()`
2. `vtkLookingGlassRenderWindowImpl::DoStereoRender()`
3. The ParaView plugin

An optional `renderFunc` argument was added specifically for the
`vtkLookingGlassPass` case, where instead of calling `Render()` on the
renderers as the other two cases do, it needs to call `Render()` on its
`DelegatePass` with a separate `vtkRenderState*` argument.

I tried to also look into resizing the render window (to match the
`RenderSize`) inside the `RenderQuilt()` function. This would work for
the ParaView plugin, which has separate render windows for rendering
the quilt and rendering to the display, but:

1. For the `vtkLookingGlassPass`, it appears that we do not want to resize
the render window. I'm not entirely sure why.
2. For the `vtkLookingGlassRenderWindowImpl`, we have to bypass `SetSize()`
on the render window, at least for Linux (which uses `vtkXOpenGLRenderWindow`),
because this otherwise causes a re-render when we do not want it, and a
resulting render flash on the display.

So for the ParaView plugin and for the render window implementation, we fix the
size ourselves outside of the `RenderQuilt()` function.

This is working in my tests for all three cases.

The corresponding ParaView MR is [here](https://gitlab.kitware.com/paraview/paraview/-/merge_requests/5637).

I have tested these locally only on Linux, but I am able to also test on Mac as well.