### PR TITLE
Add several functions to the render window

### DIFF
--- a/Examples/Python/change_devices.py
+++ b/Examples/Python/change_devices.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+"""This example demonstrates changing device types
+
+The code loops through each device type and writes out a quilt image for
+each one.
+"""
+
+import vtk
+from vtk import vtkRenderingLookingGlass
+
+# Create a looking glass render window
+renWin = vtkRenderingLookingGlass.vtkLookingGlassInterface.CreateLookingGlassRenderWindow()
+
+# Declare a VTK rendering process, and add it to the window
+ren = vtk.vtkRenderer()
+renWin.AddRenderer(ren)
+
+# Add a cone
+cone = vtk.vtkConeSource()
+cone.SetRadius(2)
+cone.SetHeight(4)
+cone.SetCenter(4, 4, 2)
+cone.SetDirection(0, 0, 0)
+coneMapper = vtk.vtkPolyDataMapper()
+coneMapper.SetInputConnection(cone.GetOutputPort())
+coneActor = vtk.vtkActor()
+coneActor.SetMapper(coneMapper)
+ren.AddActor(coneActor)
+
+# Initialize the window
+renWin.Initialize()
+ren.ResetCamera()
+ren.GetActiveCamera().SetViewAngle(30)
+
+# Loop through each device type
+for device_type in renWin.GetDeviceTypes():
+    # Switch to the device
+    renWin.SetDeviceType(device_type)
+
+    # Must render before writing out the quilt
+    renWin.Render()
+
+    # The suffix encodes the tile pattern, such as "_qs5x9"
+    # This allows software to automatically determine the tile pattern
+    suffix = renWin.QuiltFileSuffix()
+
+    # Write out the quilt
+    renWin.SaveQuilt(f"quilt_{device_type}{suffix}.png")

--- a/vtkCocoaLookingGlassRenderWindow.h
+++ b/vtkCocoaLookingGlassRenderWindow.h
@@ -86,11 +86,90 @@ public:
    */
   std::string QuiltFileSuffix() const;
 
+  /**
+   * Turn on/off use of near and far clipping limits.
+   */
+  void SetUseClippingLimits(bool b);
+
+  /**
+   * Turn on/off use of near and far clipping limits.
+   */
+  bool GetUseClippingLimits() const;
+  vtkBooleanMacro(UseClippingLimits, bool);
+
+  /**
+   * Set/Get limit for the ratio of the far clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 1.2.
+   */
+  void SetFarClippingLimit(double d);
+
+  /**
+   * Set/Get limit for the ratio of the far clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 1.2.
+   */
+  double GetFarClippingLimit() const;
+
+  /**
+   * Set/Get limit for the ratio of the near clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 0.8.
+   */
+  void SetNearClippingLimit(double d);
+
+  /**
+   * Set/Get limit for the ratio of the near clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 0.8.
+   */
+  double GetNearClippingLimit() const;
+
+  /**
+   * Check if a movie quilt is currently being recorded.
+   */
+  bool IsRecordingQuilt() const;
+
+  /**
+   * Set/Get which LookingGlass device to use. DeviceIndex starts at 0 and
+   * increases.
+   */
+  void SetDeviceIndex(int i);
+
+  /**
+   * Set/Get which LookingGlass device to use. DeviceIndex starts at 0 and
+   * increases.
+   */
+  int GetDeviceIndex() const;
+
+  /**
+   * Set/Get which LookingGlass device type to target. This allows a quilt to be
+   * generated for a device that is not connected in the future.
+   */
+  void SetDeviceType(const std::string &t);
+
+  /**
+   * Set/Get which LookingGlass device type to target. This allows a quilt to be
+   * generated for a device that is not connected in the future.
+   */
+  std::string GetDeviceType() const;
+
+  /**
+   * Returns a vector of available device types.
+   */
+  static std::vector<std::string> GetDeviceTypes();
+
 protected:
   vtkCocoaLookingGlassRenderWindow();
   ~vtkCocoaLookingGlassRenderWindow() override;
 
-  vtkLookingGlassInterface* Interface;
+  vtkLookingGlassInterface* Interface = nullptr;
+
+  void InitializeInterface();
 
   void DoStereoRender() override;
   bool InStereoRender;

--- a/vtkLookingGlassInterface.h
+++ b/vtkLookingGlassInterface.h
@@ -214,7 +214,7 @@ public:
   std::string QuiltFileSuffix() const;
 
   /**
-   * Check if the quilt is currently being recorded.
+   * Check if a movie quilt is currently being recorded.
    */
   bool IsRecordingQuilt() const { return this->IsRecording; }
 

--- a/vtkLookingGlassRenderWindowImpl.h
+++ b/vtkLookingGlassRenderWindowImpl.h
@@ -21,7 +21,17 @@ vtkStandardNewMacro(className);
 //------------------------------------------------------------------------------
 className::className()
 {
-  this->Interface = vtkLookingGlassInterface::New();
+  InitializeInterface();
+}
+
+//------------------------------------------------------------------------------
+void className::InitializeInterface()
+{
+  if (!this->Interface)
+  {
+    this->Interface = vtkLookingGlassInterface::New();
+  }
+
   this->Interface->Initialize();
   this->Interface->GetDisplaySize(this->Size[0], this->Size[1]);
   this->Interface->GetDisplayPosition(this->Position[0], this->Position[1]);
@@ -117,4 +127,92 @@ const char* className::MovieFileExtension()
 std::string className::QuiltFileSuffix() const
 {
   return this->Interface->QuiltFileSuffix();
+}
+
+//------------------------------------------------------------------------------
+void className::SetUseClippingLimits(bool b)
+{
+  this->Interface->SetUseClippingLimits(b);
+}
+
+//------------------------------------------------------------------------------
+bool className::GetUseClippingLimits() const
+{
+  return this->Interface->GetUseClippingLimits();
+}
+
+//------------------------------------------------------------------------------
+void className::SetFarClippingLimit(double d)
+{
+  this->Interface->SetFarClippingLimit(d);
+}
+
+//------------------------------------------------------------------------------
+double className::GetFarClippingLimit() const
+{
+  return this->Interface->GetFarClippingLimit();
+}
+
+//------------------------------------------------------------------------------
+void className::SetNearClippingLimit(double d)
+{
+  this->Interface->SetNearClippingLimit(d);
+}
+
+//------------------------------------------------------------------------------
+double className::GetNearClippingLimit() const
+{
+  return this->Interface->GetNearClippingLimit();
+}
+
+//------------------------------------------------------------------------------
+bool className::IsRecordingQuilt() const
+{
+  return this->Interface->IsRecordingQuilt();
+}
+
+//------------------------------------------------------------------------------
+void className::SetDeviceIndex(int i)
+{
+  this->Interface->SetDeviceIndex(i);
+}
+
+//------------------------------------------------------------------------------
+int className::GetDeviceIndex() const
+{
+  return this->Interface->GetDeviceIndex();
+}
+
+//------------------------------------------------------------------------------
+void className::SetDeviceType(const std::string& t)
+{
+  // Must re-build the interface from scratch
+  if (this->Interface)
+  {
+    this->Interface->ReleaseGraphicsResources(this);
+    this->Interface->Delete();
+    this->Interface = nullptr;
+  }
+
+  this->Interface = vtkLookingGlassInterface::New();
+  this->Interface->SetDeviceType(t);
+  InitializeInterface();
+}
+
+//------------------------------------------------------------------------------
+std::string className::GetDeviceType() const
+{
+  return this->Interface->GetDeviceType();
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> className::GetDeviceTypes()
+{
+  std::vector<std::string> types;
+  for (const auto device : vtkLookingGlassInterface::GetDevices())
+  {
+    types.push_back(device.first);
+  }
+
+  return types;
 }

--- a/vtkWin32LookingGlassRenderWindow.h
+++ b/vtkWin32LookingGlassRenderWindow.h
@@ -81,11 +81,90 @@ public:
    */
   std::string QuiltFileSuffix() const;
 
+  /**
+   * Turn on/off use of near and far clipping limits.
+   */
+  void SetUseClippingLimits(bool b);
+
+  /**
+   * Turn on/off use of near and far clipping limits.
+   */
+  bool GetUseClippingLimits() const;
+  vtkBooleanMacro(UseClippingLimits, bool);
+
+  /**
+   * Set/Get limit for the ratio of the far clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 1.2.
+   */
+  void SetFarClippingLimit(double d);
+
+  /**
+   * Set/Get limit for the ratio of the far clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 1.2.
+   */
+  double GetFarClippingLimit() const;
+
+  /**
+   * Set/Get limit for the ratio of the near clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 0.8.
+   */
+  void SetNearClippingLimit(double d);
+
+  /**
+   * Set/Get limit for the ratio of the near clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 0.8.
+   */
+  double GetNearClippingLimit() const;
+
+  /**
+   * Check if a movie quilt is currently being recorded.
+   */
+  bool IsRecordingQuilt() const;
+
+  /**
+   * Set/Get which LookingGlass device to use. DeviceIndex starts at 0 and
+   * increases.
+   */
+  void SetDeviceIndex(int i);
+
+  /**
+   * Set/Get which LookingGlass device to use. DeviceIndex starts at 0 and
+   * increases.
+   */
+  int GetDeviceIndex() const;
+
+  /**
+   * Set/Get which LookingGlass device type to target. This allows a quilt to be
+   * generated for a device that is not connected in the future.
+   */
+  void SetDeviceType(const std::string &t);
+
+  /**
+   * Set/Get which LookingGlass device type to target. This allows a quilt to be
+   * generated for a device that is not connected in the future.
+   */
+  std::string GetDeviceType() const;
+
+  /**
+   * Returns a vector of available device types.
+   */
+  static std::vector<std::string> GetDeviceTypes();
+
 protected:
   vtkWin32LookingGlassRenderWindow();
   ~vtkWin32LookingGlassRenderWindow() override;
 
-  vtkLookingGlassInterface* Interface;
+  vtkLookingGlassInterface* Interface = nullptr;
+
+  void InitializeInterface();
 
   void DoStereoRender() override;
   bool InStereoRender;

--- a/vtkXLookingGlassRenderWindow.h
+++ b/vtkXLookingGlassRenderWindow.h
@@ -81,11 +81,90 @@ public:
    */
   std::string QuiltFileSuffix() const;
 
+  /**
+   * Turn on/off use of near and far clipping limits.
+   */
+  void SetUseClippingLimits(bool b);
+
+  /**
+   * Turn on/off use of near and far clipping limits.
+   */
+  bool GetUseClippingLimits() const;
+  vtkBooleanMacro(UseClippingLimits, bool);
+
+  /**
+   * Set/Get limit for the ratio of the far clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 1.2.
+   */
+  void SetFarClippingLimit(double d);
+
+  /**
+   * Set/Get limit for the ratio of the far clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 1.2.
+   */
+  double GetFarClippingLimit() const;
+
+  /**
+   * Set/Get limit for the ratio of the near clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 0.8.
+   */
+  void SetNearClippingLimit(double d);
+
+  /**
+   * Set/Get limit for the ratio of the near clipping plane to the focal
+   * distance. This is a mechanism to limit parallex and resulting
+   * ghosting when using the looking glass display. The typical value
+   * should be around 0.8.
+   */
+  double GetNearClippingLimit() const;
+
+  /**
+   * Check if a movie quilt is currently being recorded.
+   */
+  bool IsRecordingQuilt() const;
+
+  /**
+   * Set/Get which LookingGlass device to use. DeviceIndex starts at 0 and
+   * increases.
+   */
+  void SetDeviceIndex(int i);
+
+  /**
+   * Set/Get which LookingGlass device to use. DeviceIndex starts at 0 and
+   * increases.
+   */
+  int GetDeviceIndex() const;
+
+  /**
+   * Set/Get which LookingGlass device type to target. This allows a quilt to be
+   * generated for a device that is not connected in the future.
+   */
+  void SetDeviceType(const std::string &t);
+
+  /**
+   * Set/Get which LookingGlass device type to target. This allows a quilt to be
+   * generated for a device that is not connected in the future.
+   */
+  std::string GetDeviceType() const;
+
+  /**
+   * Returns a vector of available device types.
+   */
+  static std::vector<std::string> GetDeviceTypes();
+
 protected:
   vtkXLookingGlassRenderWindow();
   ~vtkXLookingGlassRenderWindow() override;
 
-  vtkLookingGlassInterface* Interface;
+  vtkLookingGlassInterface* Interface = nullptr;
+
+  void InitializeInterface();
 
   void DoStereoRender() override;
   bool InStereoRender;


### PR DESCRIPTION
This exposes several `vtkLookingGlassInterface` functions on the render
window classes, which make them easier to access, including in Python.
These are functions that we intend for users to have easy access to.