### PR TITLE
Keep track of device aspect ratios

### DIFF
--- a/vtkLookingGlassInterface.h
+++ b/vtkLookingGlassInterface.h
@@ -72,6 +72,11 @@ public:
 
   vtkGetMacro(ViewAngle, double);
 
+  // The aspect ratio to use when adjusting the camera to render the tiles.
+  // This is modifiable so that we can generate quilts for devices that have
+  // a different aspect ratio than the device currently connected.
+  vtkGetMacro(AdjustCameraAspectRatio, double);
+
   // Return the position in pixels in the quilt for that tile
   void GetTilePosition(int tile, int pos[2]);
 
@@ -267,11 +272,12 @@ protected:
    */
   struct DeviceSettings
   {
-    DeviceSettings(const std::string& name, int quiltWidth, int quiltHeight,
-                   int quiltTilesColumns, int quiltTilesRows);
+    DeviceSettings(const std::string& name, int quiltWidth, int quiltHeight, int quiltTilesColumns,
+      int quiltTilesRows, double aspectRatio);
     DeviceSettings() = default;
     int QuiltSize[2];
     int QuiltTiles[2];
+    double AspectRatio;
     std::string Name;
   };
 
@@ -341,6 +347,11 @@ protected:
 
   // Are we recording a movie
   bool IsRecording;
+
+  // The aspect ratio to use when adjusting the camera to render the tiles.
+  // This is modifiable so that we can generate quilts for devices that have
+  // a different aspect ratio than the device currently connected.
+  double AdjustCameraAspectRatio;
 
   // For recording a movie
   vtkImageData* MovieImageBuffer;


### PR DESCRIPTION
Previously, the aspect ratio of the currently connected device would
be used when generating a quilt/image for a different device. This was
incorrect, and would make the quilts appear blurry.

Instead, keep track of the aspect ratios for the various devices, and
use that aspect ratio when generating a quilt for that device.

This, for instance, makes quilts generated for a "Portrait" device look
much nicer even though a "Large" device was connected at the time of
the quilt generation.