### PR TITLE
Replace hpc_TeardownMessagePipe with hpc_CloseApp

### DIFF
--- a/vtkLookingGlassInterface.cxx
+++ b/vtkLookingGlassInterface.cxx
@@ -202,7 +202,7 @@ vtkLookingGlassInterface::~vtkLookingGlassInterface()
   // must tear down the message pipe before shut down the app
   if (this->Connected)
   {
-    hpc_TeardownMessagePipe();
+    hpc_CloseApp();
     this->Connected = false;
   }
 }
@@ -417,7 +417,7 @@ void vtkLookingGlassInterface::Initialize(void)
   if (!GetLookingGlassInfo())
   {
     // must tear down the message pipe before shut down the app
-    hpc_TeardownMessagePipe();
+    hpc_CloseApp();
     this->Connected = false;
   }
   else


### PR DESCRIPTION
I tested this out by confirming that the `change_devices.py` example script
works (which involves destroying and rebuilding the
vtkLookingGlassInterface for every device type, which also involves
closing the app).

It seems to work without issues.

Fixes: #17