### PR TITLE
Update Looking Glass Core

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -76,6 +76,13 @@ jobs:
       - name: Build wheels
         run: cibuildwheel --output-dir wheelhouse
 
+      - name: Upload skbuild if an error occurred (for debugging)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: skbuild
+          path: ${{ github.workspace }}/_skbuild
+
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,6 +22,9 @@ env:
   # In the Linux docker container, install the wheel SDKs to this location
   CIBW_ENVIRONMENT_LINUX: VTK_WHEEL_SDK_INSTALL_PATH=/vtk-wheel-sdk
 
+  # Build both x86_64 and arm64 (through cross-compilation) wheels on Mac
+  CIBW_ARCHS_MACOS: x86_64 arm64
+
   # VTK already fixes the rpaths, so we can skip this step for MacOS
   CIBW_REPAIR_WHEEL_COMMAND_MACOS:
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,8 +23,11 @@ env:
   # In the Linux docker container, install the wheel SDKs to this location
   CIBW_ENVIRONMENT_LINUX: VTK_WHEEL_SDK_INSTALL_PATH=/vtk-wheel-sdk
 
+  # NOTE: cross-compilation is not currently working for us for arm64.
+  # We are going to turn it off and build them manually until GitHub Actions
+  # makes arm64 runners available.
   # Build both x86_64 and arm64 (through cross-compilation) wheels on Mac
-  CIBW_ARCHS_MACOS: x86_64 arm64
+  # CIBW_ARCHS_MACOS: x86_64 arm64
 
   # VTK already fixes the rpaths, so we can skip this step for MacOS
   CIBW_REPAIR_WHEEL_COMMAND_MACOS:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -14,7 +14,8 @@ on:
 
 env:
   # Only support 64-bit CPython >= 3.7
-  CIBW_SKIP: "cp27-* cp35-* cp36-* cp311-* pp* *-manylinux_i686 *-musllinux_* *-win32"
+  # VTK does not currently build python 3.8 arm64 wheels, so skip it too
+  CIBW_SKIP: "cp27-* cp35-* cp36-* cp311-* pp* *-manylinux_i686 *-musllinux_* *-win32 cp38-macosx_arm64"
 
   # Need to match the version used by VTK
   CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ elseif (WIN32)
 elseif (VTK_USE_COCOA)
   list(APPEND sources vtkCocoaLookingGlassRenderWindow.mm)
   list(APPEND headers vtkCocoaLookingGlassRenderWindow.h)
+  # For some reason, this isn't being added automatically, so add it now
+  add_definitions(-DVTK_USE_COCOA)
 endif()
 
 

--- a/FetchHoloPlayCore.cmake
+++ b/FetchHoloPlayCore.cmake
@@ -1,11 +1,21 @@
 include(FetchContent)
 
+if (UNIX AND NOT APPLE)
+  # Downgrade the version that Linux uses, because the latest version was
+  # built with too new of a glibc version.
+  set(lookingglass_file "HoloPlayCore-0.1.1-Open-20200923.tar.gz")
+  set(lookingglass_md5 b435316fa1f8454ba180e72608c3c28f)
+else ()
+  set(lookingglass_file "LookingGlassCoreSDK-Open-20220819.tgz")
+  set(lookingglass_md5 23a2a373c9d1c0f203251dc244f97f79)
+endif ()
+
 set(proj HoloPlayCore)
 set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
 FetchContent_Populate(${proj}
   SOURCE_DIR   ${EP_SOURCE_DIR}
-  URL          https://www.paraview.org/files/dependencies/LookingGlassCoreSDK-Open-20220819.tgz
-  URL_HASH MD5=23a2a373c9d1c0f203251dc244f97f79
+  URL          "https://www.paraview.org/files/dependencies/${lookingglass_file}"
+  URL_HASH     "MD5=${lookingglass_md5}"
   QUIET
   )
 

--- a/FetchHoloPlayCore.cmake
+++ b/FetchHoloPlayCore.cmake
@@ -4,8 +4,8 @@ set(proj HoloPlayCore)
 set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
 FetchContent_Populate(${proj}
   SOURCE_DIR   ${EP_SOURCE_DIR}
-  URL          https://www.paraview.org/files/dependencies/HoloPlayCore-0.1.1-Open-20200923.tar.gz
-  URL_HASH MD5=b435316fa1f8454ba180e72608c3c28f
+  URL          https://www.paraview.org/files/dependencies/LookingGlassCoreSDK-Open-20220819.tgz
+  URL_HASH MD5=23a2a373c9d1c0f203251dc244f97f79
   QUIET
   )
 

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,15 @@ def auto_download_vtk_wheel_sdk():
 
     platform_suffix = platform_suffixes[sys.platform]
 
-    if sys.platform == 'darwin' and sys.version_info[:2] > (3, 9):
-        # The platform suffix is slightly different on Mac here
-        platform_suffix = 'macosx_10_10_universal2'
+    if sys.platform == 'darwin':
+        if sys.version_info[:2] > (3, 9):
+            # The platform suffix is slightly different on Mac here
+            platform_suffix = 'macosx_10_10_universal2'
+
+        if os.environ.get('ARCHFLAGS') == '-arch arm64':
+            # It's an arm64 build
+            # See: https://github.com/pypa/cibuildwheel/discussions/997
+            platform_suffix = 'macosx_11_0_arm64'
 
     dir_name = f'{prefix}-{sdk_version}-{py_version}'
     default_install_path = Path('.').resolve() / f'_deps/{dir_name}'

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import platform
 import shutil
 import subprocess
 import sys
@@ -44,9 +45,13 @@ def auto_download_vtk_wheel_sdk():
             # The platform suffix is slightly different on Mac here
             platform_suffix = 'macosx_10_10_universal2'
 
-        if os.environ.get('ARCHFLAGS') == '-arch arm64':
+        is_arm = (
+            platform.machine() == 'arm64' or
+            # ARCHFLAGS: see https://github.com/pypa/cibuildwheel/discussions/997
+            os.getenv('ARCHFLAGS') == '-arch arm64'
+        )
+        if is_arm:
             # It's an arm64 build
-            # See: https://github.com/pypa/cibuildwheel/discussions/997
             platform_suffix = 'macosx_11_0_arm64'
 
     dir_name = f'{prefix}-{sdk_version}-{py_version}-{platform_suffix}'

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def auto_download_vtk_wheel_sdk():
             # See: https://github.com/pypa/cibuildwheel/discussions/997
             platform_suffix = 'macosx_11_0_arm64'
 
-    dir_name = f'{prefix}-{sdk_version}-{py_version}'
+    dir_name = f'{prefix}-{sdk_version}-{py_version}-{platform_suffix}'
     default_install_path = Path('.').resolve() / f'_deps/{dir_name}'
     install_path = Path(os.getenv('VTK_WHEEL_SDK_INSTALL_PATH',
                                   default_install_path))

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,11 @@ elif sys.platform == 'darwin':
     # We currently have to add this for the render window to get compiled
     cmake_args.append('-DVTK_USE_COCOA:BOOL=ON')
 
+    if os.getenv('ARCHFLAGS') == '-arch arm64':
+        # We are cross-compiling and need to set CMAKE_SYSTEM_NAME as well.
+        # NOTE: we haven't actually succeeded in cross-compiling this module.
+        cmake_args.append('-DCMAKE_SYSTEM_NAME=Darwin')
+
 setup(
     name='vtk-lookingglass',
     description='Looking Glass support for VTK Python.',


### PR DESCRIPTION
This updates Looking Glass Core to the latest version, which also supports arm64 wheels on Mac, so they are being added as well.