### PR TITLE
COMP: Portrait device playlists only support the yuv420p colormap

### DIFF
--- a/Examples/Python/cinematic_rendering/head_and_neck_animation.py
+++ b/Examples/Python/cinematic_rendering/head_and_neck_animation.py
@@ -12,7 +12,7 @@ or WEBM format. If VTK writes out the video in a different format,
 it may need to be converted. Here's an example of a conversion
 using ffmpeg:
 
-ffmpeg -i input_file.ogv -c:v libx264 -pix_fmt yuv420p -crf 10 output_file.mp4
+ffmpeg -i input_file.ogv -c:v libx265 -pix_fmt yuv420p -crf 10 output_file.mp4
 
 Where `libx265` specifies to use the h.265 video codec, `crf`
 specifies the video quality (where 0 is lossless and 51 is the lowest

--- a/Examples/Python/cinematic_rendering/head_and_neck_animation.py
+++ b/Examples/Python/cinematic_rendering/head_and_neck_animation.py
@@ -12,11 +12,12 @@ or WEBM format. If VTK writes out the video in a different format,
 it may need to be converted. Here's an example of a conversion
 using ffmpeg:
 
-ffmpeg -i input_file.ogv -c:v libx265 -crf 10 output_file.mp4
+ffmpeg -i input_file.ogv -c:v libx264 -pix_fmt yuv420p -crf 10 output_file.mp4
 
-Where `libx265` specifies to use the h.265 video codec, and `crf`
+Where `libx265` specifies to use the h.265 video codec, `crf`
 specifies the video quality (where 0 is lossless and 51 is the lowest
-quality).
+quality), and 'pix_fmt' is required if you want to include the
+mp4 in a playlist that is sync'd with a portrait device.
 
 Example output of this script that was generated for a 16" device and
 converted to MP4 may be found here:
@@ -66,9 +67,7 @@ ren.SetBackground(0, 0, 0)
 # renWin.SetSize(800, 800)
 renWin = vtkRenderingLookingGlass.vtkLookingGlassInterface.CreateLookingGlassRenderWindow()
 
-if renWin.GetDeviceType() == "standard":
-    # This looks better on large settings
-    renWin.SetDeviceType("large")
+renWin.SetDeviceType("portrait")
 
 renWin.AddRenderer(ren)
 


### PR DESCRIPTION
It isn't well described on their website, but Portrait devices require you to use yuv420p colormap if you want to sync an mp4 with the device for stand-alone playback.   This isn't a requirement if you only want to playback on connected devices.

See the note on this page regarding using ffmpeg to combine multiple files into a movie...
https://docs.lookingglassfactory.com/keyconcepts/quilts/quilt-video-encoding