### PR TITLE
COMP: Streamline client project integration by explicitly including "vector"

### DIFF
--- a/vtkCocoaLookingGlassRenderWindow.h
+++ b/vtkCocoaLookingGlassRenderWindow.h
@@ -22,6 +22,7 @@
 
 #include "vtkCocoaRenderWindow.h"
 #include "vtkRenderingLookingGlassModule.h" // For export macro
+#include <vector>
 
 class vtkLookingGlassInterface;
 

--- a/vtkWin32LookingGlassRenderWindow.h
+++ b/vtkWin32LookingGlassRenderWindow.h
@@ -22,6 +22,7 @@
 
 #include "vtkRenderingLookingGlassModule.h" // For export macro
 #include "vtkWin32OpenGLRenderWindow.h"
+#include <vector>
 
 class vtkLookingGlassInterface;
 

--- a/vtkXLookingGlassRenderWindow.h
+++ b/vtkXLookingGlassRenderWindow.h
@@ -22,6 +22,7 @@
 
 #include "vtkRenderingLookingGlassModule.h" // For export macro
 #include "vtkXOpenGLRenderWindow.h"
+#include <vector>
 
 class vtkLookingGlassInterface;
 


### PR DESCRIPTION
This commit fixes regression introduced in b99fa7324 (Add several functions to the render window) allowing client project to successfully build without having to include "vector" header.