### PR TITLE
Remove deprecated include vtkVectorOperators.h

### DIFF
--- a/vtkLookingGlassInterface.cxx
+++ b/vtkLookingGlassInterface.cxx
@@ -61,7 +61,7 @@ IN THE SOFTWARE.
 #include "vtkRendererCollection.h"
 #include "vtkShaderProgram.h"
 #include "vtkTextureObject.h"
-#include "vtkVectorOperators.h"
+#include "vtkVector.h"
 
 #include "vtk_glad.h"
 


### PR DESCRIPTION
Needed for compatibility with ParaView/VTK master.